### PR TITLE
fix: don't overwrite intersect with empty cursor cache

### DIFF
--- a/input/chainsync/chainsync.go
+++ b/input/chainsync/chainsync.go
@@ -231,7 +231,9 @@ func (c *ChainSync) setupConnection() error {
 						}
 					}
 					// Set the intersect points from the cursor cache
-					c.intersectPoints = c.cursorCache[:]
+					if len(c.cursorCache) > 0 {
+						c.intersectPoints = c.cursorCache[:]
+					}
 					// Restart the connection
 					if err := c.Start(); err != nil {
 						if c.logger != nil {


### PR DESCRIPTION
Fixes #149