### PR TITLE
feat: include original block/TX object in chainsync events

### DIFF
--- a/input/chainsync/block.go
+++ b/input/chainsync/block.go
@@ -25,6 +25,7 @@ type BlockContext struct {
 }
 
 type BlockEvent struct {
+	Block            ledger.Block     `json:"-"`
 	BlockBodySize    uint64           `json:"blockBodySize"`
 	IssuerVkey       string           `json:"issuerVkey"`
 	BlockHash        string           `json:"blockHash"`
@@ -51,6 +52,7 @@ func NewBlockHeaderContext(block ledger.BlockHeader) BlockContext {
 
 func NewBlockEvent(block ledger.Block, includeCbor bool) BlockEvent {
 	evt := BlockEvent{
+		Block:            block,
 		BlockBodySize:    block.BlockBodySize(),
 		BlockHash:        block.Hash(),
 		IssuerVkey:       block.IssuerVkey().Hash().String(),

--- a/input/chainsync/tx.go
+++ b/input/chainsync/tx.go
@@ -28,6 +28,7 @@ type TransactionContext struct {
 }
 
 type TransactionEvent struct {
+	Transaction     ledger.Transaction         `json:"-"`
 	BlockHash       string                     `json:"blockHash"`
 	TransactionCbor byteSliceJsonHex           `json:"transactionCbor,omitempty"`
 	Inputs          []ledger.TransactionInput  `json:"inputs"`
@@ -59,11 +60,12 @@ func NewTransactionEvent(
 	includeCbor bool,
 ) TransactionEvent {
 	evt := TransactionEvent{
-		BlockHash: block.Hash(),
-		Inputs:    tx.Inputs(),
-		Outputs:   tx.Outputs(),
-		Fee:       tx.Fee(),
-		TTL:       tx.TTL(),
+		Transaction: tx,
+		BlockHash:   block.Hash(),
+		Inputs:      tx.Inputs(),
+		Outputs:     tx.Outputs(),
+		Fee:         tx.Fee(),
+		TTL:         tx.TTL(),
 	}
 	if includeCbor {
 		evt.TransactionCbor = tx.Cbor()


### PR DESCRIPTION
This allows access to all underlying block/TX attributes when embedding snek as a library